### PR TITLE
Add 'hinting' to mp4 conversion.

### DIFF
--- a/video_sp.inc
+++ b/video_sp.inc
@@ -29,7 +29,7 @@ class VideoCreation {
 
       //makes mp4 file, adds file in ingest list
       $mp4file = $clean_name . '_.mp4';
-      $command_string = "$this->executable -i $file -f mp4 -vcodec libx264 -preset medium -acodec libfaac -ab 128k -ac 2 -async 1 $mp4file";
+      $command_string = "$this->executable -i $file -f mp4 -vcodec libx264 -preset medium -acodec libfaac -ab 128k -ac 2 -async 1 -movflags faststart $mp4file";
       exec($command_string, $output, $returnValue);
 
       if ($returnValue == '0') {
@@ -129,7 +129,7 @@ class VideoExiftool {
   }
 
   /**
-   * display metadata 
+   * display metadata
    * @return html
    */
   function displayMetadata() {


### PR DESCRIPTION
Add 'hinting' to the mp4 stream conversion process. This will allow a video to start playing right away by putting the encoder metadata at the beginning of the file. H/T to @dltj.
