### PR TITLE
Move OBJ data stream above derivatives.

### DIFF
--- a/xml/islandora_video_ds_composite_model.xml
+++ b/xml/islandora_video_ds_composite_model.xml
@@ -12,6 +12,15 @@
   <dsTypeModel ID="MODS" optional="true">
     <form FORMAT_URI="http://www.loc.gov/mods/v3" MIME="application/xml"/>
   </dsTypeModel>
+  <dsTypeModel ID="OBJ">
+    <form MIME="video/mp4"/>
+    <form MIME="video/quicktime"/>
+    <form MIME="video/m4v"/>
+    <form MIME="video/x-matroska"/>
+    <form MIME="video/ogg"/>
+    <form MIME="video/x-msvideo"/>
+    <form MIME="video/avi"/>
+  </dsTypeModel>
   <dsTypeModel ID="TECHMD">
     <form MIME="application/xml"/>
   </dsTypeModel>
@@ -31,14 +40,5 @@
   </dsTypeModel>
   <dsTypeModel ID="MP4" optional="false">
     <form MIME="video/mp4"/>
-  </dsTypeModel>
-  <dsTypeModel ID="OBJ">
-    <form MIME="video/mp4"/>
-    <form MIME="video/quicktime"/>
-    <form MIME="video/m4v"/>
-    <form MIME="video/x-matroska"/>
-    <form MIME="video/ogg"/>
-    <form MIME="video/x-msvideo"/>
-    <form MIME="video/avi"/>
   </dsTypeModel>
 </dsCompositeModel>


### PR DESCRIPTION
Partially addresses [ISLANDORA-1527](https://jira.duraspace.org/browse/ISLANDORA-1527)
# What does this Pull Request do?

Re-order datastreams to allow proper derivative creation when batch ingesting videos
# How should this be tested?

Batch ingest one or more videos using drush.
Before the derivatives (TN, OGG, MKV, MP4) files were not generated after ingest.
Now they should be generated once the objects are ingested.
