### PR TITLE
ISLANDORA-2069 if imagemagick module is installed, will resize the TN …

### DIFF
--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -192,7 +192,32 @@ function islandora_video_create_thumbnail(AbstractObject $object, $force = FALSE
       exec($tn_creation, $output, $return_value);
       file_delete($archival_file['file']);
       if ($return_value === 0) {
-        return islandora_video_add_datastream($object, 'TN', $out_file);
+        // Still not done here -- this image is the size of the video and needs
+        // to be resized to 200x200.
+        if (module_exists('imagemagick')) {
+          module_load_include('module', 'imagemagick');
+          $resized_out_file = $archival_path . '_200x200-TN.jpg';
+          $args = array();
+          $args[] = '-quality ' . escapeshellarg(variable_get('imagemagick_quality', 75));
+          $args[] = '-resize ' . escapeshellarg("200 x 200");
+          $command = escapeshellarg($out_file) . ' ' . implode(' ', $args) . ' ' . escapeshellarg($resized_out_file);
+          $output = array();
+          $ret = -1;
+          if (_imagemagick_convert_exec($command, $output, $ret) !== TRUE) {
+            $variables = array(
+              '@ret' => $ret,
+              '@command' => $command,
+              '!output' => implode('<br/>', $output),
+            );
+            watchdog('islandora_video', 'ImageMagick failed to convert.<br/>Error: @ret<br/>Command: @command <br/>Output !output', $variables, WATCHDOG_ERROR);
+            return FALSE;
+          }
+          file_unmanaged_delete($out_file);
+          return islandora_video_add_datastream($object, 'TN', $resized_out_file);
+        }
+        else {
+          return islandora_video_add_datastream($object, 'TN', $out_file);
+        }
       }
       // Unable to generate with Ffmpeg, add default TN.
       else {


### PR DESCRIPTION
…to 200x200

**JIRA Ticket**: (link)
https://jira.duraspace.org/browse/ISLANDORA-2069

# What does this Pull Request do?
This updates the derivatives.inc file so that it will call imagemagick if the module is installed - to resize the resultant TN derivative to 200x200.

A brief description of what the intended result of the PR will be and/or what problem it solves.
This will resize the TN derivative using Imagemagick if it exists in order to make the TN sized to the same settings as all other TN.

# What's new?
A in-depth description of the changes made by this PR. Technical details and possible side effects.
This change only impacts TN derivatives that are generated after this change is merged.  The old TN derivatives would be large while the new TN would be sized to fit within 200x200.

# How should this be tested?
Before pulling in this changeset, ingest a video (that has dimensions greater than 200x200 of course) or view the TN from any pre-existing video object.  Note that its dimensions are the same as the video.

After pulling in this changeset, regenerate the derivatives for the same video and then view the TN derivative.  It should now be able to fit within 200x200 pixels.


# Additional Notes:
This change should not require any change to documentation or impact the execution of any code -- other than to add a second or two to the duration of derivative generation of video objects.  It does not require any additional dependency because the code simply checks to see if the imagemagick module is installed before trying to call the imagemagick resize image code.