### PR TITLE
Add drupal alter for video/mp4 mimetype.

### DIFF
--- a/islandora_video.module
+++ b/islandora_video.module
@@ -183,3 +183,14 @@ function islandora_video_islandora_sp_videoCModel_islandora_derivative() {
   }
   return $derivatives;
 }
+
+/**
+ * Implements hook_file_mimetype_mapping_alter().
+ */
+function islandora_video_file_mimetype_mapping_alter(&$mapping) {
+  // Make sure the mapping is sensible for video/mp4 by removing
+  // it from array and adding it to end so it has priority.
+  $code = $mapping['extensions']['mp4'];
+  unset($mapping['extensions']['mp4']);
+  $mapping['extensions']['mp4'] = $code;
+}


### PR DESCRIPTION
## JIRA Ticket

https://jira.duraspace.org/browse/ISLANDORA-1500

## What does this Pull Request do?

Fixes the file extension when downloading video files from Islandora.

## What's new?

Add `hook_file_mimetype_mapping_alter` so that `video/mp4` has the correct extension.

## How should this be tested?

* Create a new video
* Go into the manage tab and click `download` on the MP4 datastream.
* Before patch it should give a filename like MP4.f4p 
* After patch it should give MP4.mp4

## Additional Notes:

The mime is defined in Drupal here:
https://github.com/drupal/drupal/blob/7.x/includes/file.mimetypes.inc#L839

# Interested parties
@Islandora/7-x-1-x-committers