### PR TITLE
ISLANDORA-2160 Don't validate codec if not using it.

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -109,7 +109,8 @@ function islandora_video_admin(array $form, array &$form_state) {
 }
 
 /**
- * Form submit for allowing the deletion of the viewer variable.
+ * Form submit to delete the configuration variables. Everything else is handled
+ * by system_settings_form().
  */
 function islandora_video_admin_submit($form, &$form_state) {
   $op = $form_state['clicked_button']['#id'];
@@ -132,6 +133,11 @@ function islandora_video_admin_submit($form, &$form_state) {
  * Form validation ensuring the selected ffmpeg options are available.
  */
 function islandora_video_admin_validate($form, &$form_state) {
+  // Don't validate if resetting.
+  $op = $form_state['clicked_button']['#id'];
+  if ($op == 'edit-reset') {
+    return;
+  }
   // Ensure the mp4 audio codec is present if MP4 derivative is enabled.
   if ($form_state['values']['islandora_video_make_mp4_locally'] == TRUE) {
     $raw_value = $form_state['values']['islandora_video_mp4_audio_codec'];

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -140,14 +140,30 @@ function islandora_video_admin_validate($form, &$form_state) {
         form_set_error('islandora_video_mp4_audio_codec', "The value entered for MP4 audio codec contains forbidden characters.");
         return;
       }
+      // Lower-case the value because all codecs in ffmpeg are lower case.
+      $codec = strtolower(trim($raw_value));
+      $form_state['values']['islandora_video_mp4_audio_codec'] = $codec;
+
+      // Test that FFMPEG path is valid.
       $ffmpeg = ($form_state['values']['islandora_video_ffmpeg_path'] !== variable_get('islandora_video_ffmpeg_path', 'ffmpeg') ? $form_state['values']['islandora_video_ffmpeg_path'] : variable_get('islandora_video_ffmpeg_path', 'ffmpeg'));
-      $safe_value = strtolower(trim($raw_value));
-      $command = $ffmpeg . ' -encoders 2>/dev/null | grep "^ ...... ' . $safe_value . ' "';
-      exec($command, $output, $ret);
-      if (!$output) {
-        form_set_error('islandora_video_mp4_audio_codec', 'The selected MP4 codec was not found in ffmpeg. Try using aac or enable the desired codec.');
+      if (preg_match('/[^0-9a-zA-Z\\/\\\\_-]/', $ffmpeg) === 1) {
+        form_set_error('islandora_video_ffmpeg_path', "The value entered for FFmpeg path contains forbidden characters.");
+        return;
       }
-      $form_state['values']['islandora_video_mp4_audio_codec'] = $safe_value;
+      $command = $ffmpeg . ' -version';
+      exec($command, $output, $ret);
+      if ($ret !== 0) {
+        form_set_error('islandora_video_ffmpeg_path', "FFmpeg was not found. A valid FFmpeg path is required if MP4 derivative generation is enabled.");
+      }
+      else {
+        // Test that the specified codec is present.
+        unset($output);
+        $command = $ffmpeg . ' -encoders 2>/dev/null | grep "^ ...... ' . $codec . ' "';
+        exec($command, $output, $ret);
+        if (!$output) {
+          form_set_error('islandora_video_mp4_audio_codec', 'The selected MP4 codec was not found in ffmpeg. Try using aac or enable the desired codec.');
+        }
+      }
     }
     else {
       $form_state['values']['islandora_video_mp4_audio_codec'] = 'libfaac';

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -134,39 +134,37 @@ function islandora_video_admin_submit($form, &$form_state) {
 function islandora_video_admin_validate($form, &$form_state) {
   // Ensure the mp4 audio codec is present if MP4 derivative is enabled.
   if ($form_state['values']['islandora_video_make_mp4_locally'] == TRUE) {
+    // If no value is given, set the form to use and validate the default.
     $raw_value = $form_state['values']['islandora_video_mp4_audio_codec'];
-    if ($raw_value) {
-      if (preg_match('/[^0-9a-zA-Z_-]/', $raw_value) === 1) {
-        form_set_error('islandora_video_mp4_audio_codec', "The value entered for MP4 audio codec contains forbidden characters.");
-        return;
-      }
-      // Lower-case the value because all codecs in ffmpeg are lower case.
-      $codec = strtolower(trim($raw_value));
-      $form_state['values']['islandora_video_mp4_audio_codec'] = $codec;
+    $codec = strtolower(trim($raw_value));
+    if (!$codec) {
+      $codec = 'libfaac';
+    }
+    $form_state['values']['islandora_video_mp4_audio_codec'] = $codec;
+    if (preg_match('/[^0-9a-zA-Z_-]/', $codec) === 1) {
+      form_set_error('islandora_video_mp4_audio_codec', "The value entered for MP4 audio codec contains forbidden characters.");
+      return;
+    }
 
-      // Test that FFMPEG path is valid.
-      $ffmpeg = ($form_state['values']['islandora_video_ffmpeg_path'] !== variable_get('islandora_video_ffmpeg_path', 'ffmpeg') ? $form_state['values']['islandora_video_ffmpeg_path'] : variable_get('islandora_video_ffmpeg_path', 'ffmpeg'));
-      if (preg_match('/[^0-9a-zA-Z\\/\\\\_-]/', $ffmpeg) === 1) {
-        form_set_error('islandora_video_ffmpeg_path', "The value entered for FFmpeg path contains forbidden characters.");
-        return;
-      }
-      $command = $ffmpeg . ' -version';
-      exec($command, $output, $ret);
-      if ($ret !== 0) {
-        form_set_error('islandora_video_ffmpeg_path', "FFmpeg was not found. A valid FFmpeg path is required if MP4 derivative generation is enabled.");
-      }
-      else {
-        // Test that the specified codec is present.
-        unset($output);
-        $command = $ffmpeg . ' -encoders 2>/dev/null | grep "^ ...... ' . $codec . ' "';
-        exec($command, $output, $ret);
-        if (!$output) {
-          form_set_error('islandora_video_mp4_audio_codec', 'The selected MP4 codec was not found in ffmpeg. Try using aac or enable the desired codec.');
-        }
-      }
+    // Test that FFMPEG path is valid.
+    $ffmpeg = ($form_state['values']['islandora_video_ffmpeg_path'] !== variable_get('islandora_video_ffmpeg_path', 'ffmpeg') ? $form_state['values']['islandora_video_ffmpeg_path'] : variable_get('islandora_video_ffmpeg_path', 'ffmpeg'));
+    if (preg_match('/[^0-9a-zA-Z\\/\\\\_-]/', $ffmpeg) === 1) {
+      form_set_error('islandora_video_ffmpeg_path', "The value entered for FFmpeg path contains forbidden characters.");
+      return;
+    }
+    $command = $ffmpeg . ' -version';
+    exec($command, $output, $ret);
+    if ($ret !== 0) {
+      form_set_error('islandora_video_ffmpeg_path', "FFmpeg was not found. A valid FFmpeg path is required if MP4 derivative generation is enabled.");
     }
     else {
-      $form_state['values']['islandora_video_mp4_audio_codec'] = 'libfaac';
+      // Test that the specified codec is present.
+      unset($output);
+      $command = $ffmpeg . ' -encoders 2>/dev/null | grep "^ ...... ' . $codec . ' "';
+      exec($command, $output, $ret);
+      if (!$output) {
+        form_set_error('islandora_video_mp4_audio_codec', 'The selected MP4 codec was not found in ffmpeg. Try using aac or enable the desired codec.');
+      }
     }
   }
 }

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -133,7 +133,7 @@ function islandora_video_admin_submit($form, &$form_state) {
  */
 function islandora_video_admin_validate($form, &$form_state) {
   // Ensure the mp4 audio codec is present if MP4 derivative is enabled.
-  if ($form_state['values']['islandora_video_make_mp4_locally'] == 1) {
+  if ($form_state['values']['islandora_video_make_mp4_locally'] == TRUE) {
     $raw_value = $form_state['values']['islandora_video_mp4_audio_codec'];
     if ($raw_value) {
       if (preg_match('/[^0-9a-zA-Z_-]/', $raw_value) === 1) {

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -133,8 +133,7 @@ function islandora_video_admin(array $form, array &$form_state) {
 }
 
 /**
- * Form submit to delete the configuration variables. Everything else is handled
- * by system_settings_form().
+ * Submit function for the system_settings_form to reset config variables.
  */
 function islandora_video_admin_submit($form, &$form_state) {
   $op = $form_state['clicked_button']['#id'];

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -60,6 +60,11 @@ function islandora_video_admin(array $form, array &$form_state) {
         '!FFMPEG' => l(t("FFmpeg's AAC encoding guide"), 'https://trac.ffmpeg.org/wiki/Encode/AAC'),
       )),
     '#default_value' => variable_get('islandora_video_mp4_audio_codec', 'libfaac'),
+    '#states' => array(
+      'invisible' => array(
+        ':input[name="islandora_video_make_mp4_locally"]' => array('checked' => FALSE),
+      ),
+    ),
   );
 
   // Theora configuration.
@@ -127,23 +132,25 @@ function islandora_video_admin_submit($form, &$form_state) {
  * Form validation ensuring the selected ffmpeg options are available.
  */
 function islandora_video_admin_validate($form, &$form_state) {
-  // Ensure the mp4 audio codec is enabled.
-  $raw_value = $form_state['values']['islandora_video_mp4_audio_codec'];
-  if ($raw_value) {
-    if (preg_match('/[^0-9a-zA-Z_-]/', $raw_value) === 1) {
-      form_set_error('', "The value entered for MP4 audio codec contains forbidden characters.");
-      return;
+  // Ensure the mp4 audio codec is present if MP4 derivative is enabled.
+  if ($form_state['values']['islandora_video_make_mp4_locally'] == 1) {
+    $raw_value = $form_state['values']['islandora_video_mp4_audio_codec'];
+    if ($raw_value) {
+      if (preg_match('/[^0-9a-zA-Z_-]/', $raw_value) === 1) {
+        form_set_error('islandora_video_mp4_audio_codec', "The value entered for MP4 audio codec contains forbidden characters.");
+        return;
+      }
+      $ffmpeg = ($form_state['values']['islandora_video_ffmpeg_path'] !== variable_get('islandora_video_ffmpeg_path', 'ffmpeg') ? $form_state['values']['islandora_video_ffmpeg_path'] : variable_get('islandora_video_ffmpeg_path', 'ffmpeg'));
+      $safe_value = strtolower(trim($raw_value));
+      $command = $ffmpeg . ' -encoders 2>/dev/null | grep "^ ...... ' . $safe_value . ' "';
+      exec($command, $output, $ret);
+      if (!$output) {
+        form_set_error('islandora_video_mp4_audio_codec', 'The selected MP4 codec was not found in ffmpeg. Try using aac or enable the desired codec.');
+      }
+      $form_state['values']['islandora_video_mp4_audio_codec'] = $safe_value;
     }
-    $ffmpeg = ($form_state['values']['islandora_video_ffmpeg_path'] !== variable_get('islandora_video_ffmpeg_path', 'ffmpeg') ? $form_state['values']['islandora_video_ffmpeg_path'] : variable_get('islandora_video_ffmpeg_path', 'ffmpeg'));
-    $safe_value = strtolower(trim($raw_value));
-    $command = $ffmpeg . ' -encoders 2>/dev/null | grep "^ ...... ' . $safe_value . ' "';
-    exec($command, $output, $ret);
-    if (!$output) {
-      form_set_error('', 'The selected MP4 codec was not found in ffmpeg. Try using aac or enable the desired codec.');
+    else {
+      $form_state['values']['islandora_video_mp4_audio_codec'] = 'libfaac';
     }
-    $form_state['values']['islandora_video_mp4_audio_codec'] = $safe_value;
-  }
-  else {
-    $form_state['values']['islandora_video_mp4_audio_codec'] = 'libfaac';
   }
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2160

# What does this Pull Request do?

Lets you save the Video SP form if you aren't making MP4's locally and don't have ffmpeg.

# What's new?

Validation of whether the MP4 audio codec is present now only runs when the MP4 derivative generation is enabled. Also, the field is invisible when it's not needed.

# How should this be tested?

*Replicate:* Set up a machine without ffmpeg enabled (or to mimic this, set the path to ffmpeg in the Video SP config to something totally wrong).  Disable MP4 datastream generation - and you can't save the form. You will have to turn off derivative generation using Drush or Devel or other hacky methods.

*Test fix:*  With this fix, you can save the form to turn off local MP4 generation if you don't have ffmpeg. 

# Additional Notes:

Example:
* Does this change require documentation to be updated? Not really - the screenshots show the form with that checkbox enabled.
* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? No.

# Interested parties
@Islandora/7-x-1-x-committers
