### PR TITLE
Update README.md 7.x 1.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Compilation guides:
 Sample compile flags: ` --prefix=/usr/local/stow/ffmpeg-1.1.4 --enable-gpl --enable-version3 --enable-nonfree --enable-postproc --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libdc1394 --enable-libfaac --enable-libgsm --enable-libmp3lame --enable-libopenjpeg --enable-libschroedinger --enable-libspeex --enable-libtheora --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libxvid --enable-libfdk-aac`
 
 ## Installation
+Install as a Drupal module; see [this](https://www.drupal.org/docs/7/extend/installing-modules) for further information. This module requires new Fedora objects. If enabling through Drush, use the administrative user (e.g. drush en -u 1 islandora_audio).
 
 Install as usual, see [this](https://www.drupal.org/docs/7/extend/installing-modules) for further information.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Compilation guides:
 Sample compile flags: ` --prefix=/usr/local/stow/ffmpeg-1.1.4 --enable-gpl --enable-version3 --enable-nonfree --enable-postproc --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libdc1394 --enable-libfaac --enable-libgsm --enable-libmp3lame --enable-libopenjpeg --enable-libschroedinger --enable-libspeex --enable-libtheora --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libxvid --enable-libfdk-aac`
 
 ## Installation
-Install as a Drupal module; see [this](https://www.drupal.org/docs/7/extend/installing-modules) for further information. This module requires new Fedora objects. If enabling through Drush, use the administrative user (e.g. drush en -u 1 islandora_audio).
+Install as a Drupal module; see [this](https://www.drupal.org/docs/7/extend/installing-modules) for further information. This module installs required Fedora objects. If enabling through Drush, use the administrative user (e.g. drush en -u 1 islandora_audio).
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ Sample compile flags: ` --prefix=/usr/local/stow/ffmpeg-1.1.4 --enable-gpl --ena
 ## Installation
 Install as a Drupal module; see [this](https://www.drupal.org/docs/7/extend/installing-modules) for further information. This module requires new Fedora objects. If enabling through Drush, use the administrative user (e.g. drush en -u 1 islandora_audio).
 
-Install as usual, see [this](https://www.drupal.org/docs/7/extend/installing-modules) for further information.
-
 ## Configuration
 
 Configure this module, including which (if any) derivatives to create, and which (if any) viewer to use at Administration » Islandora » Solution Pack Configuration » Video Solution Pack (admin/islandora/solution_pack_config/video).


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2240

# What does this Pull Request do?

See discussion at https://github.com/mjordan/islandora_solution_pack_remote_resource/issues/8#issuecomment-392284969

Documentation for every module, pretty much, under installation instructions, says "Install as usual, see this for further information."

This instruction depends on the reader's interpretation of "as usual". If the user installs a Solution Pack and enables it using Drush, it will not actually work (i.e. it will not provide the required Fedora objects) unless the user adds the "-u 1" parameter to the Drush command.

Proposal: Amend all documentation for all Solution Pack modules (and any other modules that require it) with the following:

Where it says "Install as usual", modify to: "Install as a Drupal module; see this for further information. This module requires new Fedora objects. If enabling through Drush, use the administrative user (e.g. drush en -u 1 islandora_audio)."

# What's new?
Documentation

# How should this be tested?
N/A

# Additional Notes:
N/A

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/7-x-1-x-committers
